### PR TITLE
replace client volume, update start script for client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,4 +7,4 @@ RUN npm i
 ADD . /usr/local/src
 EXPOSE 3000
 
-CMD ["npm", "run-script", "start"]
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     build: ./client
     ports:
       - 3000
+    volumes:
+      - ./client:/usr/local/src
     environment:
       REACT_APP_API_URL: http://api-localthreat.localhost
       CI: "true"


### PR DESCRIPTION
* Replace `docker-compose` volume for client
* Update client app start script to not require global install of `react-scripts`, used `start` script as defined in `package.json`